### PR TITLE
Fix README.mkdn to render properly

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -4,25 +4,25 @@ WWW::Mechanize::Firefox - use Firefox as if it were WWW::Mechanize
 
 # SYNOPSIS
 
-  use WWW::Mechanize::Firefox;
-  my $mech = WWW::Mechanize::Firefox->new();
-  $mech->get('http://google.com');
+    use WWW::Mechanize::Firefox;
+    my $mech = WWW::Mechanize::Firefox->new();
+    $mech->get('http://google.com');
 
-  $mech->eval_in_page('alert("Hello Firefox")');
-  my $png = $mech->content_as_png();
+    $mech->eval_in_page('alert("Hello Firefox")');
+    my $png = $mech->content_as_png();
 
 This module will let you automate Firefox through the
 Mozrepl plugin. You need to have installed
 that plugin in your Firefox.
 
-For more examples see [WWW::Mechanize::Firefox::Examples](http://search.cpan.org/search?mode=module&query=WWW::Mechanize::Firefox::Examples).
+For more examples see [WWW::Mechanize::Firefox::Examples](http://search.cpan.org/perldoc?WWW::Mechanize::Firefox::Examples).
 
 # METHODS
 
-## C<< $mech->new( %args ) >>
+## `$mech->new( %args )`
 
-  use WWW::Mechanize::Firefox;
-  my $mech = WWW::Mechanize::Firefox->new();
+    use WWW::Mechanize::Firefox;
+    my $mech = WWW::Mechanize::Firefox->new();
 
 Creates a new instance and connects it to Firefox.
 
@@ -31,31 +31,18 @@ extension installed and enabled.
 
 The following options are recognized:
 
-- * 
-
-`tab` - regex for the title of the tab to reuse. If no matching tab is
+- `tab` - regex for the title of the tab to reuse. If no matching tab is
 found, the constructor dies.
 
 If you pass in the string `current`, the currently
 active tab will be used instead.
 
-- *
-
-`create` - will create a new tab if no existing tab matching
+- `create` - will create a new tab if no existing tab matching
 the criteria given in `tab` can be found.
-
-- *
-
-`activate` - make the tab the active tab
-
-- * 
-
-`launch` - name of the program to launch if we can't connect to it on
+- `activate` - make the tab the active tab
+- `launch` - name of the program to launch if we can't connect to it on
 the first try.
-
-- *
-
-`frames` - an array reference of ids of subframes to include when 
+- `frames` - an array reference of ids of subframes to include when
 searching for elements on a page.
 
 If you want to always search through all frames, just pass `1`. This
@@ -70,75 +57,69 @@ of frame selectors:
 
           frames => ['#content_frame']
 
-- * 
+- `autodie` - whether web failures converted are fatal Perl errors. See
+the `autodie` accessor. True by default to make error checking easier.
 
-`log` - array reference to log levels, passed through to [MozRepl::RemoteObject](http://search.cpan.org/search?mode=module&query=MozRepl::RemoteObject)
+To make errors non-fatal, pass
 
-- *
+    autodie => 0
 
-`bufsize` - [Net::Telnet](http://search.cpan.org/search?mode=module&query=Net::Telnet) buffer size, if the default of 1MB is not enough
+in the constructor.
 
-- * 
-
-`events` - the set of default Javascript events to listen for while
+- `log` - array reference to log levels, passed through to [MozRepl::RemoteObject](http://search.cpan.org/perldoc?MozRepl::RemoteObject)
+- `bufsize` - [Net::Telnet](http://search.cpan.org/perldoc?Net::Telnet) buffer size, if the default of 1MB is not enough
+- `events` - the set of default Javascript events to listen for while
 waiting for a reply
 
-- * 
+The default set is
 
-`app` - a premade [Firefox::Application](http://search.cpan.org/search?mode=module&query=Firefox::Application)
+  DOMFrameContentLoaded
+  DOMContentLoaded
+  pageshow
+  error
+  abort
+  stop
 
-- * 
-
-`repl` - a premade [MozRepl::RemoteObject](http://search.cpan.org/search?mode=module&query=MozRepl::RemoteObject) instance or a connection string
+- `app` - a premade [Firefox::Application](http://search.cpan.org/perldoc?Firefox::Application)
+- `repl` - a premade [MozRepl::RemoteObject](http://search.cpan.org/perldoc?MozRepl::RemoteObject) instance or a connection string
 suitable for initializing one
+- `use_queue` - whether to use the command queueing of [MozRepl::RemoteObject](http://search.cpan.org/perldoc?MozRepl::RemoteObject).
+Default is 1.
+- `js_JSON` - whether to use native JSON encoder of Firefox
 
-- * 
+    js_JSON => 'native', # force using the native JSON encoder
 
-`pre_events` - the events that are sent to an input field before its
+The default is to autodetect whether a native JSON encoder is available and
+whether the transport is UTF-8 safe.
+
+- `pre_events` - the events that are sent to an input field before its
 value is changed. By default this is `[focus]`.
-
-- * 
-
-`post_events` - the events that are sent to an input field after its
+- `post_events` - the events that are sent to an input field after its
 value is changed. By default this is `[blur, change]`.
 
 # JAVASCRIPT METHODS
 
-## C<< $mech->allow( %options ) >>
+## `$mech->allow( %options )`
 
 Enables or disables browser features for the current tab.
 The following options are recognized:
 
-- * 
-
-`plugins` 	 - Whether to allow plugin execution.
-
-- * 
-
-`javascript` 	 - Whether to allow Javascript execution.
-
-- * 
-
-`metaredirects` - Attribute stating if refresh based redirects can be allowed.
-
-- * 
-
-`frames`, `subframes` 	 - Attribute stating if it should allow subframes (framesets/iframes) or not.
-
-- * 
-
-`images` 	 - Attribute stating whether or not images should be loaded.
+- `plugins`   - Whether to allow plugin execution.
+- `javascript`    - Whether to allow Javascript execution.
+- `metaredirects` - Attribute stating if refresh based redirects can be allowed.
+- `frames`, `subframes`    - Attribute stating if it should allow subframes (framesets/iframes) or not.
+- `images`    - Attribute stating whether or not images should be loaded.
 
 Options not listed remain unchanged.
 
 ### Disable Javascript
 
-  $mech->allow( javascript => 0 );
+    $mech->allow( javascript => 0 );
 
-## C<< $mech->js_errors() >>
+## `$mech->js_errors()`
 
-  print $_->{message}
-      for $mech->js_errors();
+    print $_->{message}
+        for $mech->js_errors();
 
 An interface to the Javascript Error Console
 
@@ -147,17 +128,17 @@ Returns the list of errors in the JEC
 Maybe this should be called `js_messages` or
 `js_console_messages` instead.
 
-## C<< $mech->clear_js_errors >>
+## `$mech->clear_js_errors`
 
     $mech->clear_js_errors();
 
 Clears all Javascript messages from the console
 
-## C<< $mech->eval_in_page( $str [, $env [, $document]] ) >>
+## `$mech->eval_in_page( $str [, $env [, $document]] )`
 
-## C<< $mech->eval( $str [, $env [, $document]] ) >>
+## `$mech->eval( $str [, $env [, $document]] )`
 
-  my ($value, $type) = $mech->eval( '2+2' );
+    my ($value, $type) = $mech->eval( '2+2' );
 
 Evaluates the given Javascript fragment in the
 context of the web page.
@@ -166,7 +147,7 @@ Returns a pair of value and Javascript type.
 This allows access to variables and functions declared
 "globally" on the web page.
 
-The returned result needs to be treated with 
+The returned result needs to be treated with
 extreme care because
 it might lead to Javascript execution in the context of
 your application instead of the context of the webpage.
@@ -189,7 +170,7 @@ Also, using this method opens a potential __security risk__ as
 the returned values can be objects and using these objects
 can execute malicious code in the context of the Firefox application.
 
-## C<< $mech->unsafe_page_property_access( ELEMENT ) >>
+## `$mech->unsafe_page_property_access( ELEMENT )`
 
 Allows you unsafe access to properties of the current page. Using
 such properties is an incredibly bad idea.
@@ -199,29 +180,29 @@ this function, edit the source code.
 
 # UI METHODS
 
-See also [Firefox::Application](http://search.cpan.org/search?mode=module&query=Firefox::Application) for how to add more than one tab
+See also [Firefox::Application](http://search.cpan.org/perldoc?Firefox::Application) for how to add more than one tab
 and how to manipulate windows and tabs.
 
-## C<< $mech->application() >>
+## `$mech->application()`
 
     my $ff = $mech->application();
 
-Returns the [Firefox::Application](http://search.cpan.org/search?mode=module&query=Firefox::Application) object for manipulating
+Returns the [Firefox::Application](http://search.cpan.org/perldoc?Firefox::Application) object for manipulating
 more parts of the Firefox UI and application.
 
-## C<< $mech->tab >>
+## `$mech->tab`
 
 Gets the object that represents the Firefox tab used by WWW::Mechanize::Firefox.
 
 This method is special to WWW::Mechanize::Firefox.
 
-## C<< $mech->autodie( [$state] ) >>
+## `$mech->autodie( [$state] )`
 
   $mech->autodie(0);
 
 Accessor to get/set whether warnings become fatal.
 
-## C<< $mech->progress_listener( $source, %callbacks ) >>
+## `$mech->progress_listener( $source, %callbacks )`
 
     my $eventlistener = progress_listener(
         $browser,
@@ -236,15 +217,15 @@ get stopped. Also, all Perl callbacks will get deregistered from the
 Javascript bridge, so make sure not to use the same callback
 in different progress listeners at the same time.
 
-## C<< $mech->repl >>
+## `$mech->repl`
 
   my ($value,$type) = $mech->repl->expr('2+2');
 
-Gets the [MozRepl::RemoteObject](http://search.cpan.org/search?mode=module&query=MozRepl::RemoteObject) instance that is used.
+Gets the [MozRepl::RemoteObject](http://search.cpan.org/perldoc?MozRepl::RemoteObject) instance that is used.
 
 This method is special to WWW::Mechanize::Firefox.
 
-## C<< $mech->events >>
+## `$mech->events`
 
   $mech->events( ['load'] );
 
@@ -253,17 +234,30 @@ will wait for after requesting a new page. Returns an array reference.
 
 This method is special to WWW::Mechanize::Firefox.
 
-## C<< $mech->cookies >>
+## `$mech->on_event`
+
+  $mech->on_event(1); # prints every page load event
+
+  # or give it a callback
+  $mech->on_event(sub { warn "Page loaded with $ev->{name} event" });
+
+Gets/sets the notification handler for the Javascript event
+that finished a page load. Set it to `1` to output via `warn`,
+or a code reference to call it with the event.
+
+This method is special to WWW::Mechanize::Firefox.
+
+## `$mech->cookies`
 
   my $cookie_jar = $mech->cookies();
 
-Returns a [HTTP::Cookies](http://search.cpan.org/search?mode=module&query=HTTP::Cookies) object that was initialized
+Returns a [HTTP::Cookies](http://search.cpan.org/perldoc?HTTP::Cookies) object that was initialized
 from the live Firefox instance.
 
 __Note:__ `->set_cookie` is not yet implemented,
 as is saving the cookie jar.
 
-## C<< $mech->highlight_node( @nodes ) >>
+## `$mech->highlight_node( @nodes )`
 
     my @links = $mech->selector('a');
     $mech->highlight_node(@links);
@@ -283,16 +277,30 @@ visual state except reloading the page.
 
 # NAVIGATION METHODS
 
-## C<< $mech->get( $url, %options ) >>
+## `$mech->get( $url, %options )`
 
   $mech->get( $url, ':content_file' => $tempfile );
 
 Retrieves the URL `URL` into the tab.
 
-It returns a faked [HTTP::Response](http://search.cpan.org/search?mode=module&query=HTTP::Response) object for interface compatibility
-with [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize).
+It returns a faked [HTTP::Response](http://search.cpan.org/perldoc?HTTP::Response) object for interface compatibility
+with [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize).
 
-## C<< $mech->get_local( $filename , %options ) >>
+Recognized options:
+
+- `:content_file` - filename to store the data in
+- `no_cache` - if true, bypass the browser cache
+- `synchronize` - wait until all elements have loaded
+
+The default is to wait until all elements have loaded. You can switch
+this off by passing
+
+    synchronize => 0
+
+for example if you want to manually poll for an element that appears fairly
+early during the load of a complex page.
+
+## `$mech->get_local( $filename , %options )`
 
   $mech->get_local('test.html');
 
@@ -300,10 +308,12 @@ Shorthand method to construct the appropriate
 `file://` URI and load it into Firefox. Relative
 paths will be interpreted as relative to `$0`.
 
+This method accepts the same options as `->get()`.
+
 This method is special to WWW::Mechanize::Firefox but could
 also exist in WWW::Mechanize through a plugin.
 
-## C<< $mech->synchronize( $event, $callback ) >>
+## `$mech->synchronize( $event, $callback )`
 
 Wraps a synchronization semaphore around the callback
 and waits until the event `$event` fires on the browser.
@@ -331,13 +341,13 @@ be used instead.
 
 
 
-## C<< $mech->res >> / C<< $mech->response >>
+## `$mech->res` / `$mech->response`
 
     my $response = $mech->response();
 
-Returns the current response as a [HTTP::Response](http://search.cpan.org/search?mode=module&query=HTTP::Response) object.
+Returns the current response as a [HTTP::Response](http://search.cpan.org/perldoc?HTTP::Response) object.
 
-## C<< $mech->success >>
+## `$mech->success`
 
     $mech->get('http://google.com');
     print "Yay"
@@ -348,7 +358,7 @@ If there hasn't been an operation yet, returns false.
 
 This is a convenience function that wraps `$mech->res->is_success`.
 
-## C<< $mech->status >>
+## `$mech->status`
 
     $mech->get('http://google.com');
     print $mech->status();
@@ -357,7 +367,7 @@ This is a convenience function that wraps `$mech->res->is_success`.
 Returns the HTTP status code of the response.
 This is a 3-digit number like 200 for OK, 404 for not found, and so on.
 
-## C<< $mech->reload( [$bypass_cache] ) >>
+## `$mech->reload( [$bypass_cache] )`
 
     $mech->reload();
 
@@ -368,7 +378,7 @@ pressing `F5` (cached) and `shift-F5` (uncached).
 
 Returns the (new) response.
 
-## C<< $mech->back >>
+## `$mech->back( [$synchronize] )`
 
     $mech->back();
 
@@ -376,15 +386,15 @@ Goes one page back in the page history.
 
 Returns the (new) response.
 
-## C<< $mech->forward >>
+## `$mech->forward( [$synchronize] )`
 
     $mech->forward();
 
-Goes one page back in the page history.
+Goes one page forward in the page history.
 
 Returns the (new) response.
 
-## C<< $mech->uri >>
+## `$mech->uri`
 
     print "We are at " . $mech->uri;
 
@@ -392,21 +402,21 @@ Returns the current document URI.
 
 # CONTENT METHODS
 
-## C<< $mech->document >>
+## `$mech->document`
 
 Returns the DOM document object.
 
 This is WWW::Mechanize::Firefox specific.
 
-## C<< $mech->docshell >>
+## `$mech->docshell`
 
     my $ds = $mech->docshell;
 
-Returns the `docShell` Javascript object.
+Returns the `docShell` Javascript object associated with the tab.
 
 This is WWW::Mechanize::Firefox specific.
 
-## C<< $mech->content >>
+## `$mech->content`
 
   print $mech->content;
 
@@ -417,27 +427,26 @@ This is likely not binary-safe.
 
 It also currently only works for HTML pages.
 
-## C<< $mech->content_encoding >>
+## $mech->text()
+
+Returns the text of the current HTML content.  If the content isn't
+HTML, $mech will die.
+
+## `$mech->content_encoding`
 
     print "The content is encoded as ", $mech->content_encoding;
 
 Returns the encoding that the content is in. This can be used
 to convert the content from UTF-8 back to its native encoding.
 
-## C<< $mech->update_html( $html ) >>
+## `$mech->update_html( $html )`
 
   $mech->update_html($html);
 
 Writes `$html` into the current document. This is mostly
-implemented as a convenience method for [HTML::Display::MozRepl](http://search.cpan.org/search?mode=module&query=HTML::Display::MozRepl).
+implemented as a convenience method for [HTML::Display::MozRepl](http://search.cpan.org/perldoc?HTML::Display::MozRepl).
 
-## C<< $mech->set_tab_content $tab, $html [,$repl] >>
-
-This is a more general method that allows you to replace
-the HTML of an arbitrary tab, and not only the tab that
-WWW::Mechanize::Firefox is associated with.
-
-## C<< $mech->save_content( $localname [, $resource_directory] [, %options ] ) >>
+## `$mech->save_content( $localname [, $resource_directory] [, %options ] )`
 
   $mech->get('http://google.com');
   $mech->save_content('google search page','google search page files');
@@ -463,7 +472,7 @@ The download will
 continue in the background. It will not show up in the
 Download Manager.
 
-## C<< $mech->save_url( $url, $localname, [%options] ) >>
+## `$mech->save_url( $url, $localname, [%options] )`
 
   $mech->save_url('http://google.com','google_index.html');
 
@@ -483,7 +492,7 @@ The download will
 continue in the background. It will also not show up in the
 Download Manager.
 
-## C<< $mech->base >>
+## `$mech->base`
 
   print $mech->base;
 
@@ -494,22 +503,22 @@ tag or is the current URL.
 
 This method is specific to WWW::Mechanize::Firefox
 
-## C<< $mech->content_type >>
+## `$mech->content_type`
 
-## C<< $mech->ct >>
+## `$mech->ct`
 
   print $mech->content_type;
 
 Returns the content type of the currently loaded document
 
-## C<< $mech->is_html() >>
+## `$mech->is_html()`
 
   print $mech->is_html();
 
 Returns true/false on whether our content is HTML, according to the
 HTTP headers.
 
-## C<< $mech->title >>
+## `$mech->title`
 
   print "We are on page " . $mech->title;
 
@@ -517,22 +526,22 @@ Returns the current document title.
 
 # EXTRACTION METHODS
 
-## C<< $mech->links >>
+## `$mech->links`
 
   print $_->text . " -> " . $_->url . "\n"
       for $mech->links;
 
-Returns all links in the document as [WWW::Mechanize::Link](http://search.cpan.org/search?mode=module&query=WWW::Mechanize::Link) objects.
+Returns all links in the document as [WWW::Mechanize::Link](http://search.cpan.org/perldoc?WWW::Mechanize::Link) objects.
 
 Currently accepts no parameters. See `->xpath`
 or `->selector` when you want more control.
 
-## C<< $mech->find_link_dom( %options ) >>
+## `$mech->find_link_dom( %options )`
 
   print $_->{innerHTML} . "\n"
       for $mech->find_link_dom( text_contains => 'CPAN' );
 
-A method to find links, like [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize)'s
+A method to find links, like [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize)'s
 `->find_links` method. This method returns DOM objects from
 Firefox instead of WWW::Mechanize::Link objects.
 
@@ -540,76 +549,57 @@ Note that Firefox
 might have reordered the links or frame links in the document
 so the absolute numbers passed via `n`
 might not be the same between
-[WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize) and [WWW::Mechanize::Firefox](http://search.cpan.org/search?mode=module&query=WWW::Mechanize::Firefox).
+[WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize) and [WWW::Mechanize::Firefox](http://search.cpan.org/perldoc?WWW::Mechanize::Firefox).
 
-Returns the DOM object as [MozRepl::RemoteObject](http://search.cpan.org/search?mode=module&query=MozRepl::RemoteObject)::Instance.
+Returns the DOM object as [MozRepl::RemoteObject](http://search.cpan.org/perldoc?MozRepl::RemoteObject)::Instance.
 
 The supported options are:
 
-- *
-
-`text` and `text_contains` and `text_regex`
+- `text` and `text_contains` and `text_regex`
 
 Match the text of the link as a complete string, substring or regular expression.
 
 Matching as a complete string or substring is a bit faster, as it is
 done in the XPath engine of Firefox.
 
-- *
-
-`id` and `id_contains` and `id_regex`
+- `id` and `id_contains` and `id_regex`
 
 Matches the `id` attribute of the link completely or as part
 
-- *
-
-`name` and `name_contains` and `name_regex`
+- `name` and `name_contains` and `name_regex`
 
 Matches the `name` attribute of the link
 
-- *
-
-`url` and `url_regex`
+- `url` and `url_regex`
 
 Matches the URL attribute of the link (`href`, `src` or `content`).
 
-- *
-
-`class` - the `class` attribute of the link
-
-- *
-
-`n` - the (1-based) index. Defaults to returning the first link.
-
-- *
-
-`single` - If true, ensure that only one element is found. Otherwise croak
+- `class` - the `class` attribute of the link
+- `n` - the (1-based) index. Defaults to returning the first link.
+- `single` - If true, ensure that only one element is found. Otherwise croak
 or carp, depending on the `autodie` parameter.
-
-- *
-
-`one` - If true, ensure that at least one element is found. Otherwise croak
+- `one` - If true, ensure that at least one element is found. Otherwise croak
 or carp, depending on the `autodie` parameter.
 
 The method `croak`s if no link is found. If the `single` option is true,
 it also `croak`s when more than one link is found.
 
-## C<< $mech->find_link( %options ) >>
+## `$mech->find_link( %options )`
 
-  print $_->text . "\n"
-      for $mech->find_link_dom( text_contains => 'CPAN' );
+    print $_->text . "\n"
+        for $mech->find_link_dom( text_contains => 'CPAN' );
 
-A method quite similar to [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize)'s method.
+A method quite similar to [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize)'s method.
 The options are documented in `->find_link_dom`.
 
-Returns a [WWW::Mechanize::Link](http://search.cpan.org/search?mode=module&query=WWW::Mechanize::Link) object.
+Returns a [WWW::Mechanize::Link](http://search.cpan.org/perldoc?WWW::Mechanize::Link) object.
 
 This defaults to not look through child frames.
 
-## C<< $mech->find_all_links( %options ) >>
+## `$mech->find_all_links( %options )`
 
-  print $_->text . "\n"
-      for $mech->find_link_dom( text_regex => qr/google/i );
+    print $_->text . "\n"
+        for $mech->find_link_dom( text_regex => qr/google/i );
 
 Finds all links in the document.
 The options are documented in `->find_link_dom`.
@@ -619,10 +609,10 @@ on context.
 
 This defaults to not look through child frames.
 
-## C<< $mech->find_all_links_dom %options >>
+## `$mech->find_all_links_dom %options`
 
-  print $_->{innerHTML} . "\n"
-      for $mech->find_link_dom( text_regex => qr/google/i );
+    print $_->{innerHTML} . "\n"
+        for $mech->find_link_dom( text_regex => qr/google/i );
 
 Finds all matching linky DOM nodes in the document.
 The options are documented in `->find_link_dom`.
@@ -632,11 +622,11 @@ on context.
 
 This defaults to not look through child frames.
 
-## C<< $mech->follow_link $link >>
+## `$mech->follow_link $link`
 
-## C<< $mech->follow_link %options >>
+## `$mech->follow_link %options`
 
-  $mech->follow_link( xpath => '//a[text() = "Click here!"]' );
+    $mech->follow_link( xpath => '//a[text() = "Click here!"]' );
 
 Follows the given link. Takes the same parameters that `find_link_dom`
 uses. In addition, `synchronize` can be passed to (not) force
@@ -645,7 +635,7 @@ waiting for a new page to be loaded.
 Note that `->follow_link` will only try to follow link-like
 things like `A` tags.
 
-## C<< $mech->xpath $query, %options >>
+## `$mech->xpath $query, %options`
 
     my $link = $mech->xpath('//a[id="clickme"]', one => 1);
     # croaks if there is no link or more than one link found
@@ -657,73 +647,66 @@ Runs an XPath query in Firefox against the current document.
 
 The options allow the following keys:
 
-- *
-
-`document` - document in which the query is to be executed. Use this to
+- `document` - document in which the query is to be executed. Use this to
 search a node within a specific subframe of `$mech->document`.
-
-- *
-
-`frames` - if true, search all documents in all frames and iframes.
+- `frames` - if true, search all documents in all frames and iframes.
 This may or may not conflict with `node`. This will default to the
 `frames` setting of the WWW::Mechanize::Firefox object.
-
-- *
-
-`node` - node relative to which the query is to be executed
-
-- *
-
-`single` - If true, ensure that only one element is found. Otherwise croak
+- `node` - node relative to which the query is to be executed
+- `single` - If true, ensure that only one element is found. Otherwise croak
 or carp, depending on the `autodie` parameter.
-
-- *
-
-`one` - If true, ensure that at least one element is found. Otherwise croak
+- `one` - If true, ensure that at least one element is found. Otherwise croak
 or carp, depending on the `autodie` parameter.
-
-- *
-
-`maybe` - If true, ensure that at most one element is found. Otherwise
+- `maybe` - If true, ensure that at most one element is found. Otherwise
 croak or carp, depending on the `autodie` parameter.
-
-- *
-
-`all` - If true, return all elements found. This is the default.
+- `all` - If true, return all elements found. This is the default.
 You can use this option if you want to use `->xpath` in scalar context
 to count the number of matched elements, as it will otherwise emit a warning
 for each usage in scalar context without any of the above restricting options.
-
-- *
-
-`any` - no error is raised, no matter if an item is found or not.
+- `any` - no error is raised, no matter if an item is found or not.
 
 Returns the matched nodes.
 
 You can pass in a list of queries as an array reference for the first parameter.
+The result will then be the list of all elements matching any of the queries.
 
 This is a method that is not implemented in WWW::Mechanize.
 
 In the long run, this should go into a general plugin for
-[WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize).
+[WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize).
 
-## C<< $mech->selector $css_selector, %options >>
+## `$mech->selector $css_selector, %options`
 
-  my @text = $mech->selector('p.content');
+    my @text = $mech->selector('p.content');
 
 Returns all nodes matching the given CSS selector. If
-$css_selector is an array reference, it returns
+`$css_selector` is an array reference, it returns
 all nodes matched by any of the CSS selectors in the array.
 
 This takes the same options that `->xpath` does.
 
 In the long run, this should go into a general plugin for
-[WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize).
+[WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize).
 
-## C<< $mech->click $name [,$x ,$y] >>
+## `$mech->by_id $id, %options`
 
-  $mech->click( 'go' );
-  $mech->click({ xpath => '//button[@name="go"]' });
+    my @text = $mech->by_id('_foo:bar');
+
+Returns all nodes matching the given ids. If
+`$id` is an array reference, it returns
+all nodes matched by any of the ids in the array.
+
+This method is equivalent to calling `->xpath` :
+
+    $self->xpath(qq{//*[\@id="$_"], %options)
+
+It is convenient when your element ids get mistaken for
+CSS selectors.
+
+## `$mech->click $name [,$x ,$y]`
+
+    $mech->click( 'go' );
+    $mech->click({ xpath => '//button[@name="go"]' });
 
 Has the effect of clicking a button on the current form. The first argument
 is the `name` of the button to be clicked. The second and third arguments
@@ -735,44 +718,58 @@ no arguments simply clicks that one button.
 If you pass in a hash reference instead of a name,
 the following keys are recognized:
 
-- *
+- `selector` - Find the element to click by the CSS selector
+- `xpath` - Find the element to click by the XPath query
+- `dom` - Click on the passed DOM element
+- `id` - Click on the element with the given id
 
-`selector` - Find the element to click by the CSS selector
+This is useful if your document ids contain characters that
+do look like CSS selectors. It is equivalent to
 
-- *
+    xpath => qq{//*[\@id="$id"}
 
-`xpath` - Find the element to click by the XPath query
-
-- *
-
-`dom` - Click on the passed DOM element
-
-- *
-
-`synchronize` - Synchronize the click (default is 1)
+- `synchronize` - Synchronize the click (default is 1)
 
 Synchronizing means that WWW::Mechanize::Firefox will wait until
 one of the events listed in `events` is fired. You want to switch
 it off when there will be no HTTP response or DOM event fired, for
 example for clicks that only modify the DOM.
 
-Returns a [HTTP::Response](http://search.cpan.org/search?mode=module&query=HTTP::Response) object.
+Returns a [HTTP::Response](http://search.cpan.org/perldoc?HTTP::Response) object.
 
-As a deviation from the WWW::Mechanize API, you can also pass a 
+As a deviation from the WWW::Mechanize API, you can also pass a
 hash reference as the first parameter. In it, you can specify
 the parameters to search much like for the `find_link` calls.
 
+## `$mech->click_button( ... )`
+
+    $mech->click_button( name => 'go' );
+    $mech->click_button( input => $mybutton );
+
+Has the effect of clicking a button on the current form by specifying its
+name, value, or index. Its arguments are a list of key/value pairs. Only
+one of name, number, input or value must be specified in the keys.
+
+- `name` - name of the button
+- `value` - value of the button
+- `input` - DOM node
+- `id` - id of the button
+- `number` - number of the button
+
+If you find yourself wanting to specify a button through its
+`selector` or `xpath`, consider using `->click` instead.
+
 # FORM METHODS
 
-## C<< $mech->current_form >>
+## `$mech->current_form`
 
-  print $mech->current_form->{name};
+    print $mech->current_form->{name};
 
 Returns the current form.
 
-This method is incompatible with [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize).
+This method is incompatible with [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize).
 It returns the DOM `<form>` object and not
-a [HTML::Form](http://search.cpan.org/search?mode=module&query=HTML::Form) instance.
+a [HTML::Form](http://search.cpan.org/perldoc?HTML::Form) instance.
 
 Note that WWW::Mechanize::Firefox has little way to know
 that the current form is not displayed in the browser
@@ -781,78 +778,75 @@ you want to make sure that a fresh or no form is used,
 remove it:
 
     $mech->clear_current_form;
-    
 
 The current form will be reset by WWW::Mechanize::Firefox
 on calls to `->get()` and `->get_local()`,
 and on calls to `->submit()` and `->submit_with_fields`.
 
-## C<< $mech->form_name $name [, %options] >>
+## `$mech->form_name $name [, %options]`
 
-  $mech->form_name( 'search' );
+    $mech->form_name( 'search' );
 
 Selects the current form by its name. The options
-are identical to those accepted by the L</$mech->xpath> method.
+are identical to those accepted by the [$mech-](#pod_$mech-)xpath> method.
 
-## C<< $mech->form_id $id [, %options] >>
+## `$mech->form_id $id [, %options]`
 
-  $mech->form_id( 'login' );
+    $mech->form_id( 'login' );
 
 Selects the current form by its `id` attribute.
 The options
-are identical to those accepted by the L</$mech->xpath> method.
+are identical to those accepted by the [$mech-](#pod_$mech-)xpath> method.
 
 This is equivalent to calling
 
-    $mech->selector("#$id",single => 1,%options)
+    $mech->by_id($id,single => 1,%options)
 
-## C<< $mech->form_number $number [, %options] >>
+## `$mech->form_number $number [, %options]`
 
-  $mech->form_number( 2 );
+    $mech->form_number( 2 );
 
 Selects the _number_th form.
 The options
-are identical to those accepted by the L</$mech->xpath> method.
+are identical to those accepted by the [$mech->xpath](#pod_$mech->xpath) method.
 
-## C<< $mech->form_with_fields [$options], @fields >>
+## `$mech->form_with_fields [$options], @fields`
 
-  $mech->form_with_fields(
-      'user', 'password'
-  );
+    $mech->form_with_fields(
+        'user', 'password'
+    );
 
 Find the form which has the listed fields.
 
 If the first argument is a hash reference, it's taken
 as options to `->xpath`.
 
-See also L</$mech->submit_form>.
+See also [$mech->submit_form](#pod_$mech->submit_form).
 
-## C<< $mech->forms %options >>
+## `$mech->forms %options`
 
-  my @forms = $mech->forms();
+    my @forms = $mech->forms();
 
-When called in a list context, returns a list 
+When called in a list context, returns a list
 of the forms found in the last fetched page.
 In a scalar context, returns a reference to
 an array with those forms.
 
 The options
-are identical to those accepted by the L</$mech->selector> method.
-
-
+are identical to those accepted by the [$mech->selector](#pod_$mech->selector) method.
 
 The returned elements are the DOM `<form>` elements.
 
-## C<< $mech->field $selector, $value, [,\@pre_events [,\@post_events]] >>
+## `$mech->field $selector, $value, [,\@pre_events [,\@post_events]]`
 
-  $mech->field( user => 'joe' );
-  $mech->field( not_empty => '', [], [] ); # bypass JS validation
+    $mech->field( user => 'joe' );
+    $mech->field( not_empty => '', [], [] ); # bypass JS validation
 
 Sets the field with the name given in `$selector` to the given value.
 Returns the value.
 
 The method understands very basic CSS selectors in the value for `$selector`,
-like the [HTML::Form](http://search.cpan.org/search?mode=module&query=HTML::Form) find_input() method.
+like the [HTML::Form](http://search.cpan.org/perldoc?HTML::Form) find_input() method.
 
 A selector prefixed with '#' must match the id attribute of the input.
 A selector prefixed with '.' matches the class attribute. A selector
@@ -867,7 +861,7 @@ By default, the events set in the
 constructor for `pre_events` and `post_events`
 are triggered.
 
-## C<< $mech->value( $selector_or_element, [%options] ) >>
+## `$mech->value( $selector_or_element, [%options] )`
 
     print $mech->value( 'user' );
 
@@ -885,25 +879,25 @@ For fields that can have multiple values, like a `select` field,
 the method is context sensitive and returns the first selected
 value in scalar context and all values in list context.
 
-## C<< $mech->get_set_value( %options ) >>
+## `$mech->get_set_value( %options )`
 
 Allows fine-grained access to getting/setting a value
 with a different API. Supported keys are:
 
-  pre
-  post
-  name
-  value
+    pre
+    post
+    name
+    value
 
 in addition to all keys that `$mech->xpath` supports.
 
-## C<< $mech->select( $name, $value ) >>
+## `$mech->select( $name, $value )`
 
-## C<< $mech->select( $name, \@values ) >>
+## `$mech->select( $name, \@values )`
 
 Given the name of a `select` field, set its value to the value
 specified.  If the field is not `<select multiple>` and the
-`$value` is an array, only the __first__ value will be set. 
+`$value` is an array, only the __first__ value will be set.
 Passing `$value` as a hash with
 an `n` key selects an item by number (e.g.
 `{n => 3}` or `{n => [2,4]}`).
@@ -917,7 +911,7 @@ then all previously selected values will be cleared.
 Returns true on successfully setting the value. On failure, returns
 false and calls `$self>warn()` with an error message.
 
-## C<< $mech->tick( $name, $value [, $set ] ) >>
+## `$mech->tick( $name, $value [, $set ] )`
 
     $mech->tick("confirmation_box", 'yes');
 
@@ -927,74 +921,68 @@ Passing in a false value as the third optional argument will cause the
 checkbox to be unticked.
 
 (Un)ticking the checkbox is done by sending a click event to it if needed.
-If `$value` is `undef`, the first checkbox matching `$name` will 
+If `$value` is `undef`, the first checkbox matching `$name` will
 be (un)ticked.
 
 If `$name` is a reference to a hash, that hash will be used
 as the options to `->find_link_dom` to find the element.
 
-## C<< $mech->untick($name, $value) >>
+## `$mech->untick($name, $value)`
 
-  $mech->untick('spam_confirm','yes',undef)
+    $mech->untick('spam_confirm','yes',undef)
 
-Causes the checkbox to be unticked. Shorthand for 
+Causes the checkbox to be unticked. Shorthand for
 
-  $mech->tick($name,$value,undef)
+    $mech->tick($name,$value,undef)
 
-## C<< $mech->submit >>
+## `$mech->submit`
 
-  $mech->submit;
+    $mech->submit;
 
 Submits the current form. Note that this does __not__ fire the `onClick`
 event and thus also does not fire eventual Javascript handlers.
 Maybe you want to use `$mech->click` instead.
 
-## C<< $mech->submit_form( %options ) >>
+## `$mech->submit_form( %options )`
 
-  $mech->submit_form(
-      with_fields => {
-          user => 'me',
-          pass => 'secret',
-      }
-  );
+    $mech->submit_form(
+        with_fields => {
+            user => 'me',
+            pass => 'secret',
+        }
+    );
 
 This method lets you select a form from the previously fetched page,
 fill in its fields, and submit it. It combines the form_number/form_name,
 set_fields and click methods into one higher level call. Its arguments are
 a list of key/value pairs, all of which are optional.
 
-- *
-
-`form => $mech->current_form()`
+- `form => $mech->current_form()`
 
 Specifies the form to be filled and submitted. Defaults to the current form.
 
-- *
-
-`fields => \%fields`
+- `fields => \%fields`
 
 Specifies the fields to be filled in the current form
 
-- *
-
-`with_fields => \%fields`
+- `with_fields => \%fields`
 
 Probably all you need for the common case. It combines a smart form selector
 and data setting in one operation. It selects the first form that contains
 all fields mentioned in \%fields. This is nice because you don't need to
 know the name or number of the form to do this.
 
-(calls L</$mech->form_with_fields()> and L</$mech->set_fields()>).
+(calls [$mech->form_with_fields()](#pod_$mech->form_with_fields()) and [$mech->set_fields()](#pod_$mech->set_fields())).
 
 If you choose this, the form_number, form_name, form_id and fields options
 will be ignored.
 
-## C<< $mech->set_fields( $name => $value, ... ) >>
+## `$mech->set_fields( $name => $value, ... )`
 
-  $mech->set_fields(
-      user => 'me',
-      pass => 'secret',
-  );
+    $mech->set_fields(
+        user => 'me',
+        pass => 'secret',
+    );
 
 This method sets multiple fields of the current form. It takes a list of
 field name and value pairs. If there is more than one field with the same
@@ -1002,31 +990,31 @@ name, the first one found is set. If you want to select which of the
 duplicate field to set, use a value which is an anonymous array which
 has the field value and its number as the 2 elements.
 
-## C<< $mech->set_visible( @values ) >>
+## `$mech->set_visible( @values )`
 
-  $mech->set_visible( $username, $password );
+    $mech->set_visible( $username, $password );
 
 This method sets fields of the current form without having to know their
 names. So if you have a login screen that wants a username and password,
 you do not have to fetch the form and inspect the source (or use the
-`mech-dump` utility, installed with [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize)) to see what
+`mech-dump` utility, installed with [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize)) to see what
 the field names are; you can just say
 
-  $mech->set_visible( $username, $password );
+    $mech->set_visible( $username, $password );
 
 and the first and second fields will be set accordingly. The method is
 called set_visible because it acts only on visible fields;
-hidden form inputs are not considered. 
+hidden form inputs are not considered.
 
-The specifiers that are possible in [WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize) are not yet supported.
+The specifiers that are possible in [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize) are not yet supported.
 
-## C<< $mech->is_visible $element >>
+## `$mech->is_visible $element`
 
-## C<< $mech->is_visible %options >>
+## `$mech->is_visible %options`
 
-  if ($mech->is_visible( selector => '#login' )) {
-      print "You can log in now.";
-  };
+    if ($mech->is_visible( selector => '#login' )) {
+        print "You can log in now.";
+    };
 
 Returns true if the element is visible, that is, it is
 a member of the DOM and neither it nor its ancestors have
@@ -1036,26 +1024,18 @@ a `display` attribute of `none`.
 You can either pass in a DOM element or a set of key/value
 pairs to search the document for the element you want.
 
-- *
-
-`xpath` - the XPath query
-
-- *
-
-`selector` - the CSS selector
-
-- *
-
-`dom` - a DOM node
+- `xpath` - the XPath query
+- `selector` - the CSS selector
+- `dom` - a DOM node
 
 The remaining options are passed through to either the
-L</$mech->xpath|xpath> or L</$mech->selector|selector> method.
+[/$mech->xpath](http://search.cpan.org/perldoc?xpath) or [/$mech->selector](http://search.cpan.org/perldoc?selector) method.
 
-## C<< $mech->wait_until_invisible $element >>
+## `$mech->wait_until_invisible( $element )`
 
-## C<< $mech->wait_until_invisible %options >>
+## `$mech->wait_until_invisible( %options )`
 
-  $mech->wait_until_invisible( $please_wait );
+    $mech->wait_until_invisible( $please_wait );
 
 Waits until an element is not visible anymore.
 
@@ -1063,18 +1043,13 @@ Takes the same options as L<$mech->is_visible/->is_visible>.
 
 In addition, the following options are accepted:
 
-- *
-
-`timeout` - the timeout after which the function will `croak`. To catch
-the condition and handle it in your calling program, use an [eval](http://search.cpan.org/search?mode=module&query=eval) block.
+- `timeout` - the timeout after which the function will `croak`. To catch
+the condition and handle it in your calling program, use an [eval](http://search.cpan.org/perldoc?eval) block.
 A timeout of `0` means to never time out.
-
-- *
-
-`sleep` - the interval in seconds used to [sleep](http://search.cpan.org/search?mode=module&query=sleep). Subsecond
+- `sleep` - the interval in seconds used to [sleep](http://search.cpan.org/perldoc?sleep). Subsecond
 intervals are possible.
 
-## C<< $mech->clickables >>
+## `$mech->clickables`
 
     print "You could click on\n";
     for my $el ($mech->clickables) {
@@ -1084,9 +1059,9 @@ intervals are possible.
 Returns all clickable elements, that is, all elements
 with an `onclick` attribute.
 
-## C<< $mech->expand_frames $spec >>
+## `$mech->expand_frames( $spec )`
 
-  my @frames = $mech->expand_frames();
+    my @frames = $mech->expand_frames();
 
 Expands the frame selectors (or `1` to match all frames)
 into their respective DOM document nodes according to the current
@@ -1096,18 +1071,16 @@ This is mostly an internal method.
 
 # IMAGE METHODS
 
-## C<< $mech->content_as_png [$tab, \%coordinates ] >>
+## `$mech->content_as_png( [$tab, \%coordinates ] )`
 
     my $png_data = $mech->content_as_png();
 
 Returns the given tab or the current page rendered as PNG image.
 
-All parameters are optional. 
- 
+All parameters are optional.
 
-TAB defaults to current TAB.
-
-If the coordinates are given, that rectangle will be cut out.
+- `$tab` defaults to the current tab.
+- If the coordinates are given, that rectangle will be cut out.
 The coordinates should be a hash with the four usual entries,
 `left`,`top`,`width`,`height`.
 
@@ -1117,14 +1090,14 @@ Currently, the data transfer between Firefox and Perl
 is done Base64-encoded. It would be beneficial to find what's
 necessary to make JSON handle binary data more gracefully.
 
-## C<< $mech->element_as_png $element >>
+## `$mech->element_as_png( $element )`
 
     my $shiny = $mech->selector('#shiny', single => 1);
     my $i_want_this = $mech->element_as_png($shiny);
 
 Returns PNG image data for a single element
 
-## C<< $mech->element_coordinates $element >>
+## `$mech->element_coordinates( $element )`
 
     my $shiny = $mech->selector('#shiny', single => 1);
     my ($pos) = $mech->element_coordinates($shiny);
@@ -1138,7 +1111,7 @@ towards rendering HTML.
 
 # COOKIE HANDLING
 
-Firefox cookies will be read through [HTTP::Cookies::MozRepl](http://search.cpan.org/search?mode=module&query=HTTP::Cookies::MozRepl). This is
+Firefox cookies will be read through [HTTP::Cookies::MozRepl](http://search.cpan.org/perldoc?HTTP::Cookies::MozRepl). This is
 relatively slow currently.
 
 # INCOMPATIBILITIES WITH WWW::Mechanize
@@ -1155,35 +1128,31 @@ to be present on links, even if it's empty. This is in
 difference to WWW::Mechanize, where the `name` attribute
 can be `undef`.
 
+## Frame tags
+
+Firefox is much less lenient than WWW::Mechanize when it comes
+to FRAME tags. A page will not contain a FRAME tag if it contains
+content other than the FRAMESET. WWW::Mechanize has no such restriction.
+
 ## Unsupported Methods
 
-- *
-
-`->find_all_inputs`
+- `->find_all_inputs`
 
 This function is likely best implemented through `$mech->selector`.
 
-- *
-
-`->find_all_submits`
+- `->find_all_submits`
 
 This function is likely best implemented through `$mech->selector`.
 
-- *
-
-`->images`
+- `->images`
 
 This function is likely best implemented through `$mech->selector`.
 
-- *
-
-`->find_image`
+- `->find_image`
 
 This function is likely best implemented through `$mech->selector`.
 
-- *
-
-`->find_all_images`
+- `->find_all_images`
 
 This function is likely best implemented through `$mech->selector`.
 
@@ -1192,129 +1161,77 @@ This function is likely best implemented through `$mech->selector`.
 These functions are unlikely to be implemented because
 they make little sense in the context of Firefox.
 
-- *
-
-`->add_header`
-
-- *
-
-`->delete_header`
-
-- *
-
-`->clone`
-
-- *
-
-`->credentials( $username, $password )`
-
-- *
-
-`->get_basic_credentials( $realm, $uri, $isproxy )`
-
-- *
-
-`->clear_credentials()`
-
-- *
-
-`->put`
+- `->add_header`
+- `->delete_header`
+- `->clone`
+- `->credentials( $username, $password )`
+- `->get_basic_credentials( $realm, $uri, $isproxy )`
+- `->clear_credentials()`
+- `->put`
 
 I have no use for it
 
-- *
-
-`->post`
+- `->post`
 
 I have no use for it
 
 # TODO
 
-- *
-
-Add `limit` parameter to `->xpath()` to allow an early exit-case
+- Add `limit` parameter to `->xpath()` to allow an early exit-case
 when searching through frames.
-
-- *
-
-Implement download progress via `nsIWebBrowserPersist.progressListener`
+- Implement download progress via `nsIWebBrowserPersist.progressListener`
 and our own `nsIWebProgressListener`.
-
-- *
-
-Rip out parts of Test::HTML::Content and graft them
+- Rip out parts of Test::HTML::Content and graft them
 onto the `links()` and `find_link()` methods here.
 Firefox is a conveniently unified XPath engine.
 
 Preferrably, there should be a common API between the two.
 
-- *
-
-Spin off XPath queries (`->xpath`) and CSS selectors (`->selector`)
+- Spin off XPath queries (`->xpath`) and CSS selectors (`->selector`)
 into their own Mechanize plugin(s).
 
 # INSTALLING
 
-- *
-
-Install the `mozrepl` add-on into Firefox
-
-- *
-
-Start the `mozrepl` add-on or you will see test failures/skips
+- Install the `mozrepl` add-on into Firefox
+- Start the `mozrepl` add-on or you will see test failures/skips
 in the module when calling `->new`. You may want to set
 `mozrepl` to start when the browser starts.
 
 # SEE ALSO
 
-- *
-
-The MozRepl Firefox plugin at <http://wiki.github.com/bard/mozrepl>
-
-- *
-
-[WWW::Mechanize](http://search.cpan.org/search?mode=module&query=WWW::Mechanize) - the module whose API grandfathered this module
-
-- *
-
-[WWW::Scripter](http://search.cpan.org/search?mode=module&query=WWW::Scripter) - another WWW::Mechanize-workalike with Javascript support
-
-- *
-
-<https://developer.mozilla.org/En/FUEL/Window> for JS events relating to tabs
-
-- *
-
-<https://developer.mozilla.org/en/Code_snippets/Tabbed_browser#Reusing_tabs>
+- The MozRepl Firefox plugin at [http://wiki.github.com/bard/mozrepl](http://wiki.github.com/bard/mozrepl)
+- [WWW::Mechanize](http://search.cpan.org/perldoc?WWW::Mechanize) - the module whose API grandfathered this module
+- [WWW::Scripter](http://search.cpan.org/perldoc?WWW::Scripter) - another WWW::Mechanize-workalike with Javascript support
+- [https://developer.mozilla.org/En/FUEL/Window](https://developer.mozilla.org/En/FUEL/Window) for JS events relating to tabs
+- [https://developer.mozilla.org/en/Code_snippets/Tabbed_browser#Reusing_tabs](https://developer.mozilla.org/en/Code_snippets/Tabbed_browser#Reusing_tabs)
 for more tab info
-
-- *
-
-<https://developer.mozilla.org/en/Document_Loading_-_From_Load_Start_to_Finding_a_Handler>
+- [https://developer.mozilla.org/en/Document_Loading_-_From_Load_Start_to_Finding_a_Handler](https://developer.mozilla.org/en/Document_Loading_-_From_Load_Start_to_Finding_a_Handler)
 for information on how to possibly override the "Save As" dialog
+- [http://code.google.com/p/selenium/source/browse/trunk/javascript/firefox-driver/extension/components/promptService.js](http://code.google.com/p/selenium/source/browse/trunk/javascript/firefox-driver/extension/components/promptService.js)
+for information on how to override a lot of other prompts (like proxy etc.)
 
 # REPOSITORY
 
-The public repository of this module is 
-<http://github.com/Corion/www-mechanize-firefox>.
+The public repository of this module is
+[http://github.com/Corion/www-mechanize-firefox](http://github.com/Corion/www-mechanize-firefox).
 
 # SUPPORT
 
 The public support forum of this module is
-<http://perlmonks.org/>.
+[http://perlmonks.org/](http://perlmonks.org/).
 
 # TALKS
 
 I've given two talks about this module at Perl conferences:
 
-<http://corion.net/talks/WWW-Mechanize-FireFox/www-mechanize-firefox.html|German Perl Workshop, German>
+L<German Perl Workshop, German>
 
-<http://corion.net/talks/WWW-Mechanize-FireFox/www-mechanize-firefox.en.html|YAPC::Europe 2010, English>
+L<YAPC::Europe 2010, English>
 
 # BUG TRACKER
 
 Please report bugs in this module via the RT CPAN bug queue at
-<https://rt.cpan.org/Public/Dist/Display.html?Name=WWW-Mechanize-Firefox>
+[https://rt.cpan.org/Public/Dist/Display.html?Name=WWW-Mechanize-Firefox](https://rt.cpan.org/Public/Dist/Display.html?Name=WWW-Mechanize-Firefox)
 or via mail to L<www-mechanize-firefox-Bugs@rt.cpan.org>.
 
 # AUTHOR
@@ -1323,7 +1240,7 @@ Max Maischein `corion@cpan.org`
 
 # COPYRIGHT (c)
 
-Copyright 2009-2010 by Max Maischein `corion@cpan.org`.
+Copyright 2009-2011 by Max Maischein `corion@cpan.org`.
 
 # LICENSE
 


### PR DESCRIPTION
The markdown version of the README didn't render properly. Most notably was the code blocks; each block needs to be preceded by four spaces.

I regenerated the readme from scratch using the most up to date pod from Firefox.pm .
