### PR TITLE
Fix downloading of url

### DIFF
--- a/lib/WWW/Mechanize/Firefox.pm
+++ b/lib/WWW/Mechanize/Firefox.pm
@@ -1944,8 +1944,9 @@ sub save_url {
     my $transfer_file = $self->repl->declare(<<'JS');
 function (source,filetarget,progress,tab) {
     //new obj_URI object
-    var obj_URI = Components.classes["@mozilla.org/network/io-service;1"]
-        .getService(Components.interfaces.nsIIOService).newURI(source, null, null);
+    var ios = Components.classes["@mozilla.org/network/io-service;1"]
+                        .getService(Components.interfaces.nsIIOService)
+    var obj_URI = ios.newURI(source, null, null);
 
     //new file object
     var obj_target;
@@ -2011,7 +2012,11 @@ function (source,filetarget,progress,tab) {
     };
 
     //save file to target
-    obj_Persist.saveURI(obj_URI,null,null,null,null,obj_target,privacyContext);
+    if( version < 36.0 ) {
+        obj_Persist.saveURI(obj_URI,null,null,null,null,obj_target,privacyContext);
+    } else {
+        obj_Persist.saveURI(obj_URI,null,null, ios.referrerPolicy, null,null,obj_target,privacyContext);
+    }
     return obj_Persist
 };
 JS


### PR DESCRIPTION
As of Firefox 36 the saveURI() method take an new parameter
https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIWebBrowserPersist#saveURI%28%29

Related unit test t/70-download-url.t now passes

bug: https://rt.cpan.org/Public/Bug/Display.html?id=102649
